### PR TITLE
Add uncertainty in proportions

### DIFF
--- a/R/fit_models.r
+++ b/R/fit_models.r
@@ -18,9 +18,9 @@ utla_rt_with_covariates <- utla_rt_with_covariates %>%
   mutate(prop_variant = ifelse(prop_variant == 0, 1e-5, prop_variant),
          prop_variant = ifelse(prop_variant == 1, prop_variant - 1e-5, prop_variant))
 
-# exclude timepoints with low samples sizes (min 10 samples)
+# exclude timepoints with low samples sizes (min 100 samples)
 utla_rt_with_covariates <- utla_rt_with_covariates %>% 
-  filter(samples >= 500)
+  filter(samples >= 100)
 
 # Add custom family -------------------------------------------------------
 add_var_student <- custom_family(
@@ -94,9 +94,9 @@ fit_models <- function(gt, data, main_only = TRUE, parallel = TRUE) {
   # fit models
   static <- list()
   if (!main_only) {
-    static[["intercept"]] <- static_model(rt_mean | vreal(prop_variant) ~ 1,
+    static[["intercept"]] <- static_model(rt_mean ~ 1,
                                           prior = priors)
-    static[["region"]] <- static_model(rt_mean | vreal(prop_variant) ~ nhser_name,
+    static[["region"]] <- static_model(rt_mean ~ nhser_name,
                                        prior = c(priors,
                                                  prior(student_t(3, 0, 0.5), class = "b")))
   }
@@ -115,63 +115,63 @@ fit_models <- function(gt, data, main_only = TRUE, parallel = TRUE) {
   dynamic_models <- list()
   if (!main_only) {
     dynamic_models[["interventions_only"]] <-
-      as.formula(rt_mean | vreal(prop_variant) ~ tier)
+      as.formula(rt_mean ~ tier)
     
     dynamic_models[["interventions"]] <-
-      as.formula(rt_mean | vreal(prop_variant) ~ tier +
+      as.formula(rt_mean ~ tier +
                       retail_and_recreation + grocery_and_pharmacy + 
                       parks + transit_stations + workplaces + residential)
     
     dynamic_models[["interventions_random"]] <-
-      as.formula(rt_mean | vreal(prop_variant) ~ tier + (1 | utla_name) +
+      as.formula(rt_mean ~ tier + (1 | utla_name) +
                       retail_and_recreation + grocery_and_pharmacy + 
                       parks + transit_stations + workplaces + residential)
     
     dynamic_models[["interventions_region"]] <-
-      as.formula(rt_mean | vreal(prop_variant) ~ tier + nhser_name +
+      as.formula(rt_mean ~ tier + nhser_name +
                       retail_and_recreation + grocery_and_pharmacy + 
                       parks + transit_stations + workplaces + residential)
   }
 
   dynamic_models[["interventions_random_region"]] <-
-    as.formula(rt_mean | vreal(prop_variant) ~ tier +  (1 | utla_name) + nhser_name +
+    as.formula(rt_mean ~ tier +  (1 | utla_name) + nhser_name +
                     retail_and_recreation + grocery_and_pharmacy + 
                     parks + transit_stations + workplaces + residential)
   
   if (!main_only) {
   dynamic_models[["interventions_time_region"]] <-
-    as.formula(rt_mean | vreal(prop_variant) ~ tier + s(time, k = 9) + nhser_name +
+    as.formula(rt_mean ~ tier + s(time, k = 9) + nhser_name +
                     retail_and_recreation + grocery_and_pharmacy + 
                     parks + transit_stations + workplaces + residential)
   }
   
   dynamic_models[["interventions_time_region_random"]] <-
-    as.formula(rt_mean | vreal(prop_variant) ~ tier + s(time, k = 9) +
+    as.formula(rt_mean ~ tier + s(time, k = 9) +
                     (1 | utla_name) + nhser_name +
                     retail_and_recreation + grocery_and_pharmacy + 
                     parks + transit_stations + workplaces + residential)
   
   if (!main_only) {
     dynamic_models[["interventions_time_by_region"]] <-
-      as.formula(rt_mean | vreal(prop_variant) ~ tier + s(time, k = 9, by = nhser_name) +
+      as.formula(rt_mean ~ tier + s(time, k = 9, by = nhser_name) +
                       retail_and_recreation + grocery_and_pharmacy + 
                       parks + transit_stations + workplaces + residential)
   }
 
   dynamic_models[["interventions_time_by_random_region"]] <-
-    as.formula(rt_mean | vreal(prop_variant) ~ tier + s(time, k = 9, by = nhser_name) +
+    as.formula(rt_mean ~ tier + s(time, k = 9, by = nhser_name) +
                     (1 | utla_name) + 
                     retail_and_recreation + grocery_and_pharmacy + 
                     parks + transit_stations + workplaces + residential)
   
   if (!main_only) {
     dynamic_models[["interventions_independent_time_region"]] <-
-      as.formula(rt_mean | vreal(prop_variant) ~ tier + factor(time):nhser_name +
+      as.formula(rt_mean ~ tier + factor(time):nhser_name +
                       retail_and_recreation + grocery_and_pharmacy + 
                       parks + transit_stations + workplaces + residential)
     
     dynamic_models[["interventions_independent_time_random_region"]] <-
-      as.formula(rt_mean | vreal(prop_variant) ~ tier + factor(time):nhser_name +
+      as.formula(rt_mean ~ tier + factor(time):nhser_name +
                       (1 | utla_name) + 
                       retail_and_recreation + grocery_and_pharmacy + 
                       parks + transit_stations + workplaces + residential)

--- a/R/fit_models.r
+++ b/R/fit_models.r
@@ -14,12 +14,12 @@ utla_rt_with_covariates <- readRDS(here("data", "utla_rt_with_covariates.rds")) 
 	filter(week_infection > "2020-10-01")
 
 # add small amount of noise to 0 measurement error
-ltla_rt_with_covariates <- ltla_rt_with_covariates %>%
+utla_rt_with_covariates <- utla_rt_with_covariates %>%
   mutate(prop_variant = ifelse(prop_variant == 0, 1e-5, prop_variant),
          prop_variant = ifelse(prop_variant == 1, prop_variant - 1e-5, prop_variant))
 
 # exclude timepoints with low samples sizes (min 10 samples)
-ltla_rt_with_covariates <- ltla_rt_with_covariates %>% 
+utla_rt_with_covariates <- utla_rt_with_covariates %>% 
   filter(samples >= 500)
 
 # Add custom family -------------------------------------------------------
@@ -39,7 +39,7 @@ real add_var_student_lpdf(real y, real mu, real sigma, real nu, real alpha,
     return student_t_lpdf(y | nu, combined_mu, sigma);
                             }
 real add_var_student_rng(real mu, real sigma, real nu, real alpha, real f) {
-    real combined_mu = (1 + (alpha -1) * f) * mu;
+    real combined_mu = (1 + (alpha - 1) * f) * mu;
     return student_t_rng(nu, combined_mu, sigma);
   }
 "
@@ -112,7 +112,6 @@ fit_models <- function(gt, data, main_only = TRUE, parallel = TRUE) {
                iter = iter, ...)
   }
   # fit models
-
   dynamic_models <- list()
   if (!main_only) {
     dynamic_models[["interventions_only"]] <-


### PR DESCRIPTION
This PR scopes out using uncertainty in S-gene negativity proportions. As implemented the models fit poorly (likely due too many degrees of uncertainty) and take too long to fit to make them practical. 

Example: 

```
$interventions_random_region
 Family: add_var_student 
  Links: mu = log; sigma = identity; nu = identity; alpha = identity 
Formula: rt_mean | vreal(prop_variant) ~ tier + (1 | utla_name) + nhser_name + retail_and_recreation + grocery_and_pharmacy + parks + transit_stations + workplaces + residential 
   Data: dynamic_data (Number of observations: 628) 
Samples: 4 chains, each with iter = 2000; warmup = 500; thin = 1;
         total post-warmup samples = 6000

Group-Level Effects: 
~utla_name (Number of levels: 117) 
              Estimate Est.Error l-95% CI u-95% CI Rhat Bulk_ESS Tail_ESS
sd(Intercept)     0.01      0.01     0.00     0.03 1.00     1162     1690

Population-Level Effects: 
                                Estimate Est.Error l-95% CI u-95% CI Rhat Bulk_ESS Tail_ESS
Intercept                          -0.16      0.02    -0.21    -0.12 1.00     2095     2495
tiernone                            0.19      0.01     0.16     0.22 1.00     4299     4230
tiertier_1                          0.24      0.02     0.20     0.28 1.00     4114     4124
tiertier_2                          0.22      0.01     0.19     0.24 1.00     3669     4042
tiertier_3                          0.09      0.01     0.07     0.12 1.00     3878     4470
nhser_nameLondon                   -0.01      0.02    -0.05     0.03 1.00     2831     2655
nhser_nameMidlands                  0.03      0.02    -0.01     0.07 1.00     2134     2808
nhser_nameNorthEastandYorkshire     0.01      0.02    -0.04     0.05 1.00     1799     2346
nhser_nameNorthWest                -0.02      0.02    -0.06     0.02 1.00     2088     2826
nhser_nameSouthEast                 0.00      0.02    -0.04     0.04 1.00     2501     3120
nhser_nameSouthWest                -0.02      0.04    -0.10     0.05 1.00     3332     3499
retail_and_recreation              -0.01      0.02    -0.05     0.02 1.00     3902     3692
grocery_and_pharmacy               -0.04      0.02    -0.08     0.01 1.00     4187     3541
parks                               0.01      0.01    -0.01     0.04 1.00     6465     3803
transit_stations                   -0.01      0.01    -0.03     0.02 1.00     4777     3739
workplaces                          0.09      0.02     0.05     0.13 1.00     4669     3024
residential                         0.01      0.02    -0.03     0.05 1.00     4249     3587

Family Specific Parameters: 
      Estimate Est.Error l-95% CI u-95% CI Rhat Bulk_ESS Tail_ESS
sigma     0.08      0.00     0.07     0.09 1.00     3572     3234
nu       15.81      8.69     6.50    38.94 1.00     5644     4521
alpha     1.33      0.03     1.28     1.39 1.00     3472     3529

Samples were drawn using sampling(NUTS). For each parameter, Bulk_ESS
and Tail_ESS are effective sample size measures, and Rhat is the potential
scale reduction factor on split chains (at convergence, Rhat = 1).

Warning message:
There were 723 divergent transitions after warmup. Increasing adapt_delta above 0.95 may help. See http://mc-stan.org/misc/warnings.html#divergent-transitions-after-warmup 
```